### PR TITLE
Allow underscore to be used as an escape character for pattern --> 

### DIFF
--- a/plantuml-core/src/main/java/net/sourceforge/plantuml/cucadiagram/BodierMap.java
+++ b/plantuml-core/src/main/java/net/sourceforge/plantuml/cucadiagram/BodierMap.java
@@ -39,7 +39,7 @@ public class BodierMap implements Bodier {
 	}
 
 	public static String getLinkedEntry(String s) {
-		final Pattern p = Pattern.compile("(\\*-+\\>)");
+		final Pattern p = Pattern.compile("(\\*-+_*\\>)");
 		final Matcher m = p.matcher(s);
 		if (m.find()) {
 			return m.group(1);

--- a/plantuml-core/src/main/java/net/sourceforge/plantuml/objectdiagram/command/CommandCreateMap.java
+++ b/plantuml-core/src/main/java/net/sourceforge/plantuml/objectdiagram/command/CommandCreateMap.java
@@ -80,7 +80,7 @@ public class CommandCreateMap extends CommandMultilines2<AbstractEntityDiagram> 
 			assert line.length() > 0;
 			final boolean ok = entity1.getBodier().addFieldOrMethod(line);
 			if (ok == false)
-				return CommandExecutionResult.error("Map definition should contains key => value");
+				return CommandExecutionResult.error("Map definition should contain key => value");
 
 			if (BodierMap.getLinkedEntry(line) != null) {
 				final String linkStr = BodierMap.getLinkedEntry(line);


### PR DESCRIPTION
The issue is described in more detail at https://forum.plantuml.net/17507/dotted-arrow-also-the-close-comment-blocks-html-xml-markdown --
Similar to the issue in https://forum.plantuml.net/11806/dotted-arrow-also-the-close-comment-blocks-html-xml-markdown `map` uses the syntax with --> for longer arrows but they pose a problem when embedding in HTML.

For example, the following cannot be embedded in HTML.

    map example {

        A*--> B

    }

The linked thread above suggests the use of `_` before the `>` but that doesn't work for maps.