### PR TITLE
Allow only one underscore when escaping -->

### DIFF
--- a/plantuml-core/src/main/java/net/sourceforge/plantuml/cucadiagram/BodierMap.java
+++ b/plantuml-core/src/main/java/net/sourceforge/plantuml/cucadiagram/BodierMap.java
@@ -40,7 +40,7 @@ public class BodierMap implements Bodier {
 	}
 
 	public static String getLinkedEntry(String s) {
-		final Pattern p = Pattern.compile("(\\*[-_]+\\>)");
+		final Pattern p = Pattern.compile("(\\*-+_?\\>)");
 		final Matcher m = p.matcher(s);
 		if (m.find()) {
 			return m.group(1);


### PR DESCRIPTION
This improves #1303 by preventing expressions like *--____> from being allowed. Now only expressions like *--_> and *--> will be allowed in maps.

This duplicates changes in https://github.com/plantuml/plantuml/pull/1307